### PR TITLE
Handle array out of bounds for chatListItemArray

### DIFF
--- a/iMEGA/Chat/ChatRoomsViewController.m
+++ b/iMEGA/Chat/ChatRoomsViewController.m
@@ -707,7 +707,12 @@
                     
                 case MEGAChatListItemChangeTypeLastMsg:
                 case MEGAChatListItemChangeTypeLastTs:
-                    [self.chatListItemArray replaceObjectAtIndex:indexPath.row withObject:item];
+                   if (!self.chatListItemArray || !self.chatListItemArray.count ) {
+                       [self.chatListItemArray addObject:(item)];
+                    }
+                   else{
+                       [self.chatListItemArray replaceObjectAtIndex:indexPath.row withObject:item];
+                   }
                     [self updateCell:cell forChatListItem:item];
                     break;
                     


### PR DESCRIPTION
When using the chat, iOS would kick out an out of bounds condition if the array is null or empty.  This will resolve issues when the array has not been used yet.